### PR TITLE
Fix htlc_minimum_msat for the channel acceptor

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ use crate::rgb_utils::get_rgb_total_amount;
 use crate::rgb_utils::RgbUtilities;
 use crate::{
 	ChannelManager, HTLCStatus, MillisatAmount, NetworkGraph, OnionMessenger, PaymentInfo,
-	PaymentInfoStorage, PeerManager,
+	PaymentInfoStorage, PeerManager, HTLC_MIN_MSAT,
 };
 use crate::{FEE_RATE, UTXO_SIZE_SAT};
 
@@ -77,8 +77,6 @@ const OPENCHANNEL_MIN_SAT: u64 = 5506;
 const OPENCHANNEL_MAX_SAT: u64 = 16777215;
 
 const DUST_LIMIT_MSAT: u64 = 546000;
-
-const HTLC_MIN_MSAT: u64 = 3000000;
 
 const INVOICE_MIN_MSAT: u64 = HTLC_MIN_MSAT;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ use lightning::rgb_utils::{
 use lightning::routing::gossip;
 use lightning::routing::gossip::{NodeId, P2PGossipSync};
 use lightning::routing::router::DefaultRouter;
-use lightning::util::config::UserConfig;
+use lightning::util::config::{ChannelHandshakeConfig, UserConfig};
 use lightning::util::ser::ReadableArgs;
 use lightning_background_processor::{process_events_async, GossipSync};
 use lightning_block_sync::init;
@@ -146,6 +146,8 @@ pub(crate) type ChannelManager =
 	SimpleArcChannelManager<ChainMonitor, BitcoindClient, BitcoindClient, FilesystemLogger>;
 
 pub(crate) type NetworkGraph = gossip::NetworkGraph<Arc<FilesystemLogger>>;
+
+pub (crate) const HTLC_MIN_MSAT: u64 = 3000000;
 
 type OnionMessenger = SimpleArcOnionMessenger<FilesystemLogger>;
 
@@ -1049,7 +1051,13 @@ async fn start_ldk() {
 	));
 
 	// Step 11: Initialize the ChannelManager
-	let mut user_config = UserConfig::default();
+	let mut user_config = UserConfig {
+		channel_handshake_config: ChannelHandshakeConfig {
+			our_htlc_minimum_msat: HTLC_MIN_MSAT,
+			..Default::default()
+		},
+		..Default::default()
+	};
 	user_config.channel_handshake_limits.force_announced_channel_preference = false;
 	let mut restarting_node = true;
 	let (channel_manager_blockhash, channel_manager) = {


### PR DESCRIPTION
Previously, only the channel opener would set htlc_minimum_msat to 300000, while the channel acceptor would keep 1. This would cause some weird bugs with routing, as with small payments, channels would be usable only on one side. This commit sets htlc_minimum_msat to HTLC_MIN_MSAT for the channel acceptor as well, which is better for consistency.